### PR TITLE
Mapper API refactor

### DIFF
--- a/Sources/Initializable.swift
+++ b/Sources/Initializable.swift
@@ -1,11 +1,3 @@
-//
-//  Convertible.swift
-//  Topo
-//
-//  Created by Oleg Dreyman on 27.03.16.
-//  Copyright © 2016 Oleg Dreyman. All rights reserved.
-//
-
 import StructuredData
 
 public enum InitializableError: ErrorProtocol {

--- a/Sources/Mappable.swift
+++ b/Sources/Mappable.swift
@@ -1,23 +1,14 @@
-//
-//  Mappable.swift
-//  Topo
-//
-//  Created by Oleg Dreyman on 27.03.16.
-//  Copyright © 2016 Oleg Dreyman. All rights reserved.
-//
-
 import StructuredData
-import Foundation
 
 public protocol Mappable: StructuredDataInitializable {
     
-    init(map: Mapper) throws
+    init(mapper: Mapper) throws
     
 }
 
 extension Mappable {
     public init(structuredData: StructuredData) throws {
-        try self.init(map: structuredData.mapper)
+        try self.init(mapper: structuredData.mapper)
     }
 }
 
@@ -25,7 +16,7 @@ extension Mappable {
     
     public static func makeWith(structuredData structuredData: StructuredData) -> Self? {
         do {
-            return try self.init(map: structuredData.mapper)
+            return try self.init(mapper: structuredData.mapper)
         } catch {
             return nil
         }

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -49,21 +49,19 @@ extension Mapper {
 
 extension Mapper {
     
-    public func map<S: Sequence>(from key: String) throws -> S {
-        return try unwrap((structuredData.flatMapThrough(key) { try? $0.get() as S.Iterator.Element }) as? S)
+    public func map<T>(arrayFrom key: String) throws -> [T] {
+        return try structuredData.flatMapThrough(key) { try $0.get() as T }
     }
     
-    public func map<S: Sequence where
-                    S.Iterator.Element: StructuredDataInitializable>(from key: String) throws -> S {
-        return try unwrap((structuredData.flatMapThrough(key) { try? S.Iterator.Element(structuredData: $0) }) as? S)
+    public func map<T where T: StructuredDataInitializable>(arrayFrom key: String) throws -> [T] {
+        return try structuredData.flatMapThrough(key) { try? T(structuredData: $0) }
     }
     
-    public func map<S: Sequence where
-                    S.Iterator.Element: RawRepresentable,
-                    S.Iterator.Element.RawValue: StructuredDataInitializable>(from key: String) throws -> S {
-        return try unwrap((structuredData.flatMapThrough(key) {
-            return (try? S.Iterator.Element.RawValue(structuredData: $0)).flatMap({ S.Iterator.Element(rawValue: $0) })
-        }) as? S)
+    public func map<T: RawRepresentable where
+                    T.RawValue: StructuredDataInitializable>(arrayFrom key: String) throws -> [T] {
+        return try structuredData.flatMapThrough(key) {
+            return (try? T.RawValue(structuredData: $0)).flatMap({ T(rawValue: $0) })
+        }
     }
     
 }
@@ -105,21 +103,19 @@ extension Mapper {
 
 extension Mapper {
     
-    public func map<S: Sequence>(optionalFrom key: String) -> S? {
-        return (try? structuredData.flatMapThrough(key) { try? $0.get() as S.Iterator.Element }) as? S
+    public func map<T>(optionalArrayFrom key: String) -> [T]? {
+        return try? structuredData.flatMapThrough(key) { try $0.get() as T }
     }
     
-    public func map<S: Sequence where
-                    S.Iterator.Element: StructuredDataInitializable>(from key: String) -> S? {
-        return (try? structuredData.flatMapThrough(key) { try? S.Iterator.Element(structuredData: $0) }) as? S
+    public func map<T where T: StructuredDataInitializable>(optionalArrayFrom key: String) -> [T]? {
+        return try?  structuredData.flatMapThrough(key) { try? T(structuredData: $0) }
     }
     
-    public func map<S: Sequence where
-                    S.Iterator.Element: RawRepresentable,
-                    S.Iterator.Element.RawValue: StructuredDataInitializable>(from key: String) -> S? {
-        return (try? structuredData.flatMapThrough(key) {
-            return (try? S.Iterator.Element.RawValue(structuredData: $0)).flatMap({ S.Iterator.Element(rawValue: $0) })
-            }) as? S
+    public func map<T: RawRepresentable where
+                    T.RawValue: StructuredDataInitializable>(optionalArrayFrom key: String) -> [T]? {
+        return try? structuredData.flatMapThrough(key) {
+            return (try? T.RawValue(structuredData: $0)).flatMap({ T(rawValue: $0) })
+        }
     }
     
 }

--- a/Sources/StructuredData.swift
+++ b/Sources/StructuredData.swift
@@ -1,11 +1,3 @@
-//
-//  StructuredData.swift
-//  Topo
-//
-//  Created by Oleg Dreyman on 29.03.16.
-//  Copyright © 2016 Oleg Dreyman. All rights reserved.
-//
-
 import StructuredData
 
 extension StructuredData {

--- a/Tests/StructuredDataMapper/MappableValueTests.swift
+++ b/Tests/StructuredDataMapper/MappableValueTests.swift
@@ -32,91 +32,91 @@ class MappableValueTests: XCTestCase {
     func testNestedMappable() {
         struct Test: Mappable {
             let nest: Nested
-            init(map: Mapper) throws {
-                try self.nest = map.from("nest")
+            init(mapper: Mapper) throws {
+                try self.nest = mapper.map(from: "nest")
             }
         }
         struct Nested: Mappable {
             let string: String
-            init(map: Mapper) throws {
-                try self.string = map.from("string")
+            init(mapper: Mapper) throws {
+                try self.string = mapper.map(from: "string")
             }
         }
         let structuredData: StructuredData = [
             "nest": ["string": "hello"]
         ]
-        let test = try! Test(map: Mapper(structuredData: structuredData))
+        let test = try! Test(mapper: Mapper(structuredData: structuredData))
         XCTAssertEqual(test.nest.string, "hello")
     }
     
     func testNestedInvalidMappable() {
         struct Nested: Mappable {
             let string: String
-            init(map: Mapper) throws {
-                try self.string = map.from("string")
+            init(mapper: Mapper) throws {
+                try self.string = mapper.map(from: "string")
             }
         }
         struct Test: Mappable {
             let nested: Nested
-            init(map: Mapper) throws {
-                try self.nested = map.from("nest")
+            init(mapper: Mapper) throws {
+                try self.nested = mapper.map(from: "nest")
             }
         }
         let structuredData: StructuredData = ["nest": ["strong": "er"]]
-        let test = try? Test(map: Mapper(structuredData: structuredData))
+        let test = try? Test(mapper: Mapper(structuredData: structuredData))
         XCTAssertNil(test)
     }
     
     func testNestedOptionalMappable() {
         struct Nested: Mappable {
             let string: String
-            init(map: Mapper) throws {
-                try self.string = map.from("string")
+            init(mapper: Mapper) throws {
+                try self.string = mapper.map(from: "string")
             }
         }
         struct Test: Mappable {
             let nested: Nested?
-            init(map: Mapper) throws {
-                self.nested = map.optionalFrom("nest")
+            init(mapper: Mapper) throws {
+                self.nested = mapper.map(optionalFrom: "nest")
             }
         }
         let structuredData: StructuredData = ["nest": ["string": "zewo"]]
-        let test = try! Test(map: Mapper(structuredData: structuredData))
+        let test = try! Test(mapper: Mapper(structuredData: structuredData))
         XCTAssertEqual(test.nested!.string, "zewo")
     }
     
     func testNestedOptionalInvalidMappable() {
         struct Nested: Mappable {
             let string: String
-            init(map: Mapper) throws {
-                try self.string = map.from("string")
+            init(mapper: Mapper) throws {
+                try self.string = mapper.map(from: "string")
             }
         }
         struct Test: Mappable {
             let nested: Nested?
-            init(map: Mapper) throws {
-                self.nested = map.optionalFrom("nest")
+            init(mapper: Mapper) throws {
+                self.nested = mapper.map(optionalFrom: "nest")
             }
         }
         let structuredData: StructuredData = ["nest": ["strong": "er"]]
-        let test = try! Test(map: Mapper(structuredData: structuredData))
+        let test = try! Test(mapper: Mapper(structuredData: structuredData))
         XCTAssertNil(test.nested)
     }
     
     func testArrayOfMappables() {
         struct Nested: Mappable {
             let string: String
-            init(map: Mapper) throws {
-                try self.string = map.from("string")
+            init(mapper: Mapper) throws {
+                try self.string = mapper.map(from: "string")
             }
         }
         struct Test: Mappable {
             let nested: [Nested]
-            init(map: Mapper) throws {
-                try self.nested = map.arrayFrom("nested")
+            init(mapper: Mapper) throws {
+                try self.nested = mapper.map(arrayFrom: "nested")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: ["nested": [["string": "fire"], ["string": "sun"]]]))
+        let test = try! Test(mapper: Mapper(structuredData: ["nested": [["string": "fire"], ["string": "sun"]]]))
         XCTAssertEqual(test.nested.count, 2)
         XCTAssertEqual(test.nested[1].string, "sun")
     }
@@ -124,119 +124,119 @@ class MappableValueTests: XCTestCase {
     func testArrayOfInvalidMappables() {
         struct Nested: Mappable {
             let string: String
-            init(map: Mapper) throws {
-                try self.string = map.from("string")
+            init(mapper: Mapper) throws {
+                try self.string = mapper.map(from: "string")
             }
         }
         struct Test: Mappable {
             let nested: [Nested]
-            init(map: Mapper) throws {
-                try self.nested = map.arrayFrom("nested")
+            init(mapper: Mapper) throws {
+                try self.nested = mapper.map(arrayFrom: "nested")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: ["nested": [["string": 1], ["string": 1]]]))
+        let test = try! Test(mapper: Mapper(structuredData: ["nested": [["string": 1], ["string": 1]]]))
         XCTAssertTrue(test.nested.isEmpty)
     }
     
     func testInvalidArrayOfMappables() {
         struct Nested: Mappable {
             let string: String
-            init(map: Mapper) throws {
-                try self.string = map.from("string")
+            init(mapper: Mapper) throws {
+                try self.string = mapper.map(from: "string")
             }
         }
         struct Test: Mappable {
             let nested: [Nested]
-            init(map: Mapper) throws {
-                try self.nested = map.arrayFrom("nested")
+            init(mapper: Mapper) throws {
+                try self.nested = mapper.map(arrayFrom: "nested")
             }
         }
-        let test = try? Test(map: Mapper(structuredData: ["hested": [["strong": "fire"], ["strong": "sun"]]]))
+        let test = try? Test(mapper: Mapper(structuredData: ["hested": [["strong": "fire"], ["strong": "sun"]]]))
         XCTAssertNil(test)
     }
     
     func testArrayOfPartiallyInvalidMappables() {
         struct Nested: Mappable {
             let string: String
-            init(map: Mapper) throws {
-                try self.string = map.from("string")
+            init(mapper: Mapper) throws {
+                try self.string = mapper.map(from: "string")
             }
         }
         struct Test: Mappable {
             let nested: [Nested]
-            init(map: Mapper) throws {
-                try self.nested = map.arrayFrom("nested")
+            init(mapper: Mapper) throws {
+                try self.nested = mapper.map(arrayFrom: "nested")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: ["nested": [["string": 1], ["string": "fire"]]]))
+        let test = try! Test(mapper: Mapper(structuredData: ["nested": [["string": 1], ["string": "fire"]]]))
         XCTAssertEqual(test.nested.count, 1)
     }
     
     func testExistingOptionalArrayOfMappables() {
         struct Nested: Mappable {
             let string: String
-            init(map: Mapper) throws {
-                try self.string = map.from("string")
+            init(mapper: Mapper) throws {
+                try self.string = mapper.map(from: "string")
             }
         }
         struct Test: Mappable {
             let nested: [Nested]?
-            init(map: Mapper) throws {
-                self.nested = map.optionalArrayFrom("nested")
+            init(mapper: Mapper) throws {
+                self.nested = mapper.map(optionalArrayFrom: "nested")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: ["nested": [["string": "ring"], ["string": "fire"]]]))
+        let test = try! Test(mapper: Mapper(structuredData: ["nested": [["string": "ring"], ["string": "fire"]]]))
         XCTAssertEqual(test.nested!.count, 2)
     }
     
     func testOptionalArrayOfMappables() {
         struct Nested: Mappable {
             let string: String
-            init(map: Mapper) throws {
-                try self.string = map.from("string")
+            init(mapper: Mapper) throws {
+                try self.string = mapper.map(from: "string")
             }
         }
         struct Test: Mappable {
             let nested: [Nested]?
-            init(map: Mapper) throws {
-                self.nested = map.optionalArrayFrom("nested")
+            init(mapper: Mapper) throws {
+                self.nested = mapper.map(optionalArrayFrom: "nested")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: []))
+        let test = try! Test(mapper: Mapper(structuredData: []))
         XCTAssertNil(test.nested)
     }
     
     func testOptionalArrayOfInvalidMappables() {
         struct Nested: Mappable {
             let string: String
-            init(map: Mapper) throws {
-                try self.string = map.from("string")
+            init(mapper: Mapper) throws {
+                try self.string = mapper.map(from: "string")
             }
         }
         struct Test: Mappable {
             let nested: [Nested]?
-            init(map: Mapper) throws {
-                self.nested = map.optionalArrayFrom("nested")
+            init(mapper: Mapper) throws {
+                self.nested = mapper.map(optionalArrayFrom: "nested")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: ["nested": [["strong": 3], ["strong": 5]]]))
+        let test = try! Test(mapper: Mapper(structuredData: ["nested": [["strong": 3], ["strong": 5]]]))
         XCTAssertTrue(test.nested!.isEmpty)
     }
     
     func testOptionalArrayOfPartiallyInvalidMappables() {
         struct Nested: Mappable {
             let string: String
-            init(map: Mapper) throws {
-                try self.string = map.from("string")
+            init(mapper: Mapper) throws {
+                try self.string = mapper.map(from: "string")
             }
         }
         struct Test: Mappable {
             let nested: [Nested]?
-            init(map: Mapper) throws {
-                self.nested = map.optionalArrayFrom("nested")
+            init(mapper: Mapper) throws {
+                self.nested = mapper.map(optionalArrayFrom: "nested")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: ["nested": [["string": 1], ["string": "fire"]]]))
+        let test = try! Test(mapper: Mapper(structuredData: ["nested": [["string": 1], ["string": "fire"]]]))
         XCTAssertEqual(test.nested!.count, 1)
     }
 

--- a/Tests/StructuredDataMapper/NormalValueTests.swift
+++ b/Tests/StructuredDataMapper/NormalValueTests.swift
@@ -24,58 +24,58 @@ class NormalValueTests: XCTestCase {
     func testMappingString() {
         struct Test: Mappable {
             let string: String
-            init(map: Mapper) throws {
-                try self.string = map.from("string")
+            init(mapper: Mapper) throws {
+                try self.string = mapper.map(from: "string")
             }
         }
         
-        let test = try! Test(map: Mapper(structuredData: ["string": "Hello"]))
+        let test = try! Test(mapper: Mapper(structuredData: ["string": "Hello"]))
         XCTAssertTrue(test.string == "Hello")
     }
     
     func testMappingMissingKey() {
         struct Test: Mappable {
             let string: String
-            init(map: Mapper) throws {
-                try self.string = map.from("foo")
+            init(mapper: Mapper) throws {
+                try self.string = mapper.map(from: "foo")
             }
         }
         
-        let test = try? Test(map: Mapper(structuredData: [:]))
+        let test = try? Test(mapper: Mapper(structuredData: [:]))
         XCTAssertNil(test)
     }
     
     func testFallbackMissingKey() {
         struct Test: Mappable {
             let string: String
-            init(map: Mapper) throws {
-                self.string = map.optionalFrom("foo") ?? "Hello"
+            init(mapper: Mapper) throws {
+                self.string = mapper.map(optionalFrom: "foo") ?? "Hello"
             }
         }
         
-        let test = try! Test(map: Mapper(structuredData: [:]))
+        let test = try! Test(mapper: Mapper(structuredData: [:]))
         XCTAssertTrue(test.string == "Hello")
     }
     
     func testArrayOfStrings() {
         struct Test: Mappable {
             let strings: [String]
-            init(map: Mapper) throws {
-                try self.strings = map.arrayFrom("strings")
+            init(mapper: Mapper) throws {
+                try self.strings = mapper.map(arrayFrom: "strings")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: ["strings": ["first", "second"]]))
+        let test = try! Test(mapper: Mapper(structuredData: ["strings": ["first", "second"]]))
         XCTAssertEqual(test.strings.count, 2)
     }
     
     func testPartiallyInvalidArrayOfValues() {
         struct Test: Mappable {
             let strings: [String]
-            init(map: Mapper) throws {
-                try self.strings = map.arrayFrom("strings")
+            init(mapper: Mapper) throws {
+                try self.strings = mapper.map(arrayFrom: "strings")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: ["strings": ["first", "second", 3]]))
+        let test = try! Test(mapper: Mapper(structuredData: ["strings": ["first", "second", 3]]))
         XCTAssertEqual(test.strings.count, 2)
     }
     

--- a/Tests/StructuredDataMapper/OptionalValueTests.swift
+++ b/Tests/StructuredDataMapper/OptionalValueTests.swift
@@ -24,55 +24,55 @@ final class OptionalValueTests: XCTestCase {
     func testMappingToClass() {
         final class Test: Mappable {
             let string: String
-            required init(map: Mapper) throws {
-                self.string = map.optionalFrom("string") ?? ""
+            required init(mapper: Mapper) throws {
+                self.string = mapper.map(optionalFrom: "string") ?? ""
             }
         }
-        let test = try! Test(map: Mapper(structuredData: ["string": "Hello"]))
+        let test = try! Test(mapper: Mapper(structuredData: ["string": "Hello"]))
         XCTAssertEqual(test.string, "Hello")
     }
     
     func testMappingOptionalValue() {
         struct Test: Mappable {
             let string: String?
-            init(map: Mapper) throws {
-                self.string = map.optionalFrom("whiskey")
+            init(mapper: Mapper) throws {
+                self.string = mapper.map(optionalFrom: "whiskey")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: .nullValue))
+        let test = try! Test(mapper: Mapper(structuredData: .nullValue))
         XCTAssertNil(test.string)
     }
 
     func testMappingOptionalExisitngValue() {
         struct Test: Mappable {
             let string: String?
-            init(map: Mapper) throws {
-                string = map.optionalFrom("whiskey")
+            init(mapper: Mapper) throws {
+                string = mapper.map(optionalFrom: "whiskey")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: ["whiskey": "flows"]))
+        let test = try! Test(mapper: Mapper(structuredData: ["whiskey": "flows"]))
         XCTAssertEqual(test.string, "flows")
     }
     
     func testMappingOptionalArray() {
         struct Test: Mappable {
             let strings: [String]?
-            init(map: Mapper) throws {
-                self.strings = map.optionalArrayFrom("whiskey")
+            init(mapper: Mapper) throws {
+                self.strings = mapper.map(optionalArrayFrom: "whiskey")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: .nullValue))
+        let test = try! Test(mapper: Mapper(structuredData: .nullValue))
         XCTAssertNil(test.strings)
     }
     
     func testMappingOptionalExistingArray() {
         struct Test: Mappable {
             let strings: [String]?
-            init(map: Mapper) throws {
-                self.strings = map.optionalArrayFrom("whiskey")
+            init(mapper: Mapper) throws {
+                self.strings = mapper.map(optionalArrayFrom: "whiskey")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: ["whiskey": ["lera", "lynn"]]))
+        let test = try! Test(mapper: Mapper(structuredData: ["whiskey": ["lera", "lynn"]]))
         XCTAssertEqual(test.strings!, ["lera", "lynn"])
     }
     

--- a/Tests/StructuredDataMapper/RawRepresentableValueTests.swift
+++ b/Tests/StructuredDataMapper/RawRepresentableValueTests.swift
@@ -35,11 +35,11 @@ class RawRepresentableValueTests: XCTestCase {
         }
         struct Test: Mappable {
             let suit: Suits
-            init(map: Mapper) throws {
-                try self.suit = map.from("suit")
+            init(mapper: Mapper) throws {
+                try self.suit = mapper.map(from: "suit")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: ["suit": "barney"]))
+        let test = try! Test(mapper: Mapper(structuredData: ["suit": "barney"]))
         XCTAssertEqual(test.suit, Suits.Barney)
     }
     
@@ -49,11 +49,11 @@ class RawRepresentableValueTests: XCTestCase {
         }
         struct Test: Mappable {
             let value: Value
-            init(map: Mapper) throws {
-                try self.value = map.from("value")
+            init(mapper: Mapper) throws {
+                try self.value = mapper.map(from: "value")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: ["value": 1.0]))
+        let test = try! Test(mapper: Mapper(structuredData: ["value": 1.0]))
         XCTAssertEqual(test.value, Value.first)
     }
     
@@ -63,11 +63,11 @@ class RawRepresentableValueTests: XCTestCase {
         }
         struct Test: Mappable {
             let value: Value
-            init(map: Mapper) throws {
-                try self.value = map.from("value")
+            init(mapper: Mapper) throws {
+                try self.value = mapper.map(from: "value")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: ["value": 1]))
+        let test = try! Test(mapper: Mapper(structuredData: ["value": 1]))
         XCTAssertEqual(test.value, Value.first)
     }
     
@@ -77,11 +77,11 @@ class RawRepresentableValueTests: XCTestCase {
         }
         struct Test: Mappable {
             let value: Value
-            init(map: Mapper) throws {
-                try self.value = map.from("value")
+            init(mapper: Mapper) throws {
+                try self.value = mapper.map(from: "value")
             }
         }
-        let test = try? Test(map: Mapper(structuredData: .nullValue))
+        let test = try? Test(mapper: Mapper(structuredData: .nullValue))
         XCTAssertNil(test)
     }
     
@@ -91,11 +91,11 @@ class RawRepresentableValueTests: XCTestCase {
         }
         struct Test: Mappable {
             let value: Value?
-            init(map: Mapper) throws {
-                self.value = map.optionalFrom("value")
+            init(mapper: Mapper) throws {
+                self.value = mapper.map(optionalFrom: "value")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: .nullValue))
+        let test = try! Test(mapper: Mapper(structuredData: .nullValue))
         XCTAssertNil(test.value)
     }
     
@@ -105,11 +105,11 @@ class RawRepresentableValueTests: XCTestCase {
         }
         struct Test: Mappable {
             let value: Value?
-            init(map: Mapper) throws {
-                self.value = map.optionalFrom("value")
+            init(mapper: Mapper) throws {
+                self.value = mapper.map(optionalFrom: "value")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: ["value": 1.0]))
+        let test = try! Test(mapper: Mapper(structuredData: ["value": 1.0]))
         XCTAssertEqual(test.value, Value.First)
     }
     
@@ -119,11 +119,11 @@ class RawRepresentableValueTests: XCTestCase {
         }
         struct Test: Mappable {
             let value: Value?
-            init(map: Mapper) throws {
-                self.value = map.optionalFrom("value")
+            init(mapper: Mapper) throws {
+                self.value = mapper.map(optionalFrom: "value")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: ["value": "cike"]))
+        let test = try! Test(mapper: Mapper(structuredData: ["value": "cike"]))
         XCTAssertNil(test.value)
     }
     
@@ -133,12 +133,12 @@ class RawRepresentableValueTests: XCTestCase {
         }
         struct Test: Mappable {
             let barneys: [Barney]
-            init(map: Mapper) throws {
-                try self.barneys = map.arrayFrom("barneys")
+            init(mapper: Mapper) throws {
+                try self.barneys = mapper.map(arrayFrom: "barneys")
             }
         }
         let barneysContent: StructuredData = ["barneys": ["legendary", "stinson", "awesome"]]
-        let test = try! Test(map: Mapper(structuredData: barneysContent))
+        let test = try! Test(mapper: Mapper(structuredData: barneysContent))
         XCTAssertEqual(test.barneys, [Barney.legendary, Barney.stinson, Barney.awesome])
     }
     
@@ -148,12 +148,12 @@ class RawRepresentableValueTests: XCTestCase {
         }
         struct Test: Mappable {
             let barneys: [Barney]
-            init(map: Mapper) throws {
-                try self.barneys = map.arrayFrom("barneys")
+            init(mapper: Mapper) throws {
+                try self.barneys = mapper.map(arrayFrom: "barneys")
             }
         }
         let barneysContent: StructuredData = ["barneys": ["legendary", "stinson", "captain"]]
-        let test = try! Test(map: Mapper(structuredData: barneysContent))
+        let test = try! Test(mapper: Mapper(structuredData: barneysContent))
         XCTAssertEqual(test.barneys, [Barney.legendary, Barney.stinson])
     }
     
@@ -163,11 +163,11 @@ class RawRepresentableValueTests: XCTestCase {
         }
         struct Test: Mappable {
             let barneys: [Barney]?
-            init(map: Mapper) throws {
-                self.barneys = map.optionalArrayFrom("barneys")
+            init(mapper: Mapper) throws {
+                self.barneys = mapper.map(optionalArrayFrom: "barneys")
             }
         }
-        let test = try! Test(map: Mapper(structuredData: .nullValue))
+        let test = try! Test(mapper: Mapper(structuredData: .nullValue))
         XCTAssertNil(test.barneys)
     }
     
@@ -177,12 +177,12 @@ class RawRepresentableValueTests: XCTestCase {
         }
         struct Test: Mappable {
             let barneys: [Barney]?
-            init(map: Mapper) throws {
-                self.barneys = map.optionalArrayFrom("barneys")
+            init(mapper: Mapper) throws {
+                self.barneys = mapper.map(optionalArrayFrom: "barneys")
             }
         }
         let barneysContent: StructuredData = ["barneys": ["legendary", "stinson", "awesome"]]
-        let test = try! Test(map: Mapper(structuredData: barneysContent))
+        let test = try! Test(mapper: Mapper(structuredData: barneysContent))
         XCTAssertEqual(test.barneys!, [Barney.legendary, Barney.stinson, Barney.awesome])
     }
 


### PR DESCRIPTION
Before:

``` swift
init(map: Mapper) throws {
    string = try map.from("string")
    doubles = try map.arrayFrom("doubles")
    int = map.optionalFrom("int")
    strings = map.optionalArrayFrom("strings")
}
```

After:

``` swift
init(mapper: Mapper) throws {
    string = try mapper.map(from: "string")
    doubles = try mapper.map(arrayFrom: "doubles")
    int = mapper.map(optionalFrom: "int")
    strings = mapper.map(optionalArrayFrom: "strings")
}
```
