### PR TITLE
Fix errors being silenced mapping to array of Mappable.

### DIFF
--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -70,17 +70,21 @@ extension Mapper {
 extension Mapper {
     
     public func map<T>(arrayFrom key: String) throws -> [T] {
-        return try structuredData.flatMapThrough(key) { try $0.get() as T }
+        return try structuredData.mapThrough(key) { try $0.get() as T }
     }
     
     public func map<T where T: StructuredDataInitializable>(arrayFrom key: String) throws -> [T] {
-        return try structuredData.flatMapThrough(key) { try T(structuredData: $0) }
+        return try structuredData.mapThrough(key) { try T(structuredData: $0) }
     }
     
     public func map<T: RawRepresentable where
                     T.RawValue: StructuredDataInitializable>(arrayFrom key: String) throws -> [T] {
-        return try structuredData.flatMapThrough(key) {
-            return T(rawValue: try T.RawValue(structuredData: $0))
+        return try structuredData.mapThrough(key) {
+  					guard let value = T(rawValue: try T.RawValue(structuredData: $0)) else {
+              throw Error.cantInitFromRawValue
+  					}
+  					
+  					return value
         }
     }
 }

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -74,13 +74,13 @@ extension Mapper {
     }
     
     public func map<T where T: StructuredDataInitializable>(arrayFrom key: String) throws -> [T] {
-        return try structuredData.flatMapThrough(key) { try? T(structuredData: $0) }
+        return try structuredData.flatMapThrough(key) { try T(structuredData: $0) }
     }
     
     public func map<T: RawRepresentable where
                     T.RawValue: StructuredDataInitializable>(arrayFrom key: String) throws -> [T] {
         return try structuredData.flatMapThrough(key) {
-            return (try? T.RawValue(structuredData: $0)).flatMap({ T(rawValue: $0) })
+            return T(rawValue: try T.RawValue(structuredData: $0))
         }
     }
 }


### PR DESCRIPTION
While the new `Mapper` is coming shortly, I did find this bug and needed it fixed for my own projects.

Basically, when doing something like `let goomba: SomeMappableType = try mapper.map(arrayFrom: "key")`, any errors in mapping each value of the array will be turned into a null and not included in the array. Problem code:

https://github.com/Zewo/Mapper/blob/0.7.2/Sources/Mapper.swift#L76-L85

``` swift
    public func map<T where T: StructuredDataInitializable>(arrayFrom key: String) throws -> [T] {
        return try structuredData.flatMapThrough(key) { try? T(structuredData: $0) }
    }

    public func map<T: RawRepresentable where
                    T.RawValue: StructuredDataInitializable>(arrayFrom key: String) throws -> [T] {
        return try structuredData.flatMapThrough(key) {
            return (try? T.RawValue(structuredData: $0)).flatMap({ T(rawValue: $0) })
        }
    }
```

Specifically, the `try?` in the two closures causes `.flatMap()` to filter out any `null` values.

@dreymonde [confirmed this is a bug](https://zewo.slack.com/archives/general/p1475958293002008).
